### PR TITLE
Fix lightning tab code

### DIFF
--- a/DMI_Open_Data_dialog.py
+++ b/DMI_Open_Data_dialog.py
@@ -863,22 +863,21 @@ class DMIOpenDataDialog(QtWidgets.QDialog, FORM_CLASS):
                     'datetime' : datetime,
                       'limit' : '300000'}
 # Did the user choose the BBOX?
-            if self.bbox_lig.text() != '':
+            if self.bbox_lightning.text() != '':
                 params.update({'bbox': self.bbox_lig.text()})
 # Did the user choose any specific lightning type?
-            if self.Cloud_to_g_pos.isChecked():
+            if self.cloud_to_g_pos.isChecked():
                 params.update({'type': '1'})
                 name = 'Lightning cloud to ground (positive)'
-            elif self.Cloud_to_g_neg.isChecked():
+            elif self.cloud_to_g_neg.isChecked():
                 params.update({'type': '0'})
                 name = 'Lightning cloud to ground (negative)'
-            elif self.Cloud_to_cloud.isChecked():
+            elif self.cloud_to_cloud.isChecked():
                 params.update({'type': '2'})
                 name = 'Lightning cloud to cloud'
             else:
                 name = 'Lightning'
 # URL creation
-            url = 'https://dmigw.govcloud.dk/v2/' + data_type + '/collections/' + data_type2 + '/items'
             r = requests.get(url, params=params)
             print(r.url)
             json = r.json()

--- a/DMI_Open_Data_dialog_base.ui
+++ b/DMI_Open_Data_dialog_base.ui
@@ -38,7 +38,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>7</number>
+      <number>3</number>
      </property>
      <property name="documentMode">
       <bool>false</bool>
@@ -124,8 +124,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>98</width>
-                   <height>28</height>
+                   <width>422</width>
+                   <height>175</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10"/>
@@ -155,8 +155,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>98</width>
-                   <height>28</height>
+                   <width>421</width>
+                   <height>175</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_5"/>
@@ -308,8 +308,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>430</width>
+                  <height>206</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_14"/>
@@ -330,8 +330,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>80</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_32"/>
@@ -362,8 +362,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>80</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_36"/>
@@ -384,8 +384,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>80</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_40"/>
@@ -406,8 +406,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>429</width>
+                  <height>206</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_34"/>
@@ -690,7 +690,7 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_22">
             <item>
-             <widget class="QLineEdit" name="lineEdit_34"/>
+             <widget class="QLineEdit" name="bbox_lightning"/>
             </item>
            </layout>
           </widget>
@@ -715,21 +715,21 @@
              </widget>
             </item>
             <item>
-             <widget class="QRadioButton" name="radioButton_26">
+             <widget class="QRadioButton" name="cloud_to_g_neg">
               <property name="text">
                <string>Cloud to ground (negative)</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QRadioButton" name="radioButton_28">
+             <widget class="QRadioButton" name="cloud_to_g_pos">
               <property name="text">
                <string>Cloud to ground (positive)</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QRadioButton" name="radioButton_27">
+             <widget class="QRadioButton" name="cloud_to_cloud">
               <property name="text">
                <string>Cloud to cloud</string>
               </property>
@@ -881,8 +881,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>98</width>
-                 <height>28</height>
+                 <width>423</width>
+                 <height>177</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_100"/>


### PR DESCRIPTION
Object names from Qt UI file did not match the object names used in the
code retrieving lightnings. The consequence was that appropriate
UI elements was not accessed for user input, instead the software would
crash when running for lightning.