### PR TITLE
Create changelogs, use release notes document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
       - release:
           context:
             - GITHUB_CREDS
-          notes-file: CHANGELOG.md
+          notes-file: latest-release-notes.md
           files: /home/circleci/project/zip_build/DMI_Open_Data.zip
           requires:
             - build-and-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,30 @@
-## Changes
+## Version: 0.1.2 - Minor bugfix for lightning data
+
+### Changes
 
  - Quick fix when using "Run" for lightning data
 
-## Installation
+## Version: 0.1.1 - Minor bugfix release
 
-Download the latest zip file build from the Assets section. Install it by going to Plugins -> Manage and install plugins -> Install from ZIP, and select the zip file you just downloaded.
+### Changes
+
+- Quick fix so plugin does not crash if no radar API is set
+
+
+##  Version: 0.1.0 - Beta release!
+
+### Changes
+
+- Stations & Parameters tab fixed
+- Radar tab only supports composite images
+- Various UX improvements for missing / invalid API keys
+- Better date + time selection defaults
+- Calendar popup support for date selection
+- And much more
+
+
+## Version: 0.0.2 - Fix plugin build
+
+### Changes
+
+Fixed bug in build process, so plugin now works

--- a/latest-release-notes.md
+++ b/latest-release-notes.md
@@ -1,0 +1,8 @@
+## Changes
+
+ - Forecast tab added, forecast series can be downloaded and integrates with the Temporal Control Panel
+ - Guide for usage of the plugin
+
+## Installation
+
+Download the latest zip file build from the Assets section. Install it by going to Plugins -> Manage and install plugins -> Install from ZIP, and select the zip file you just downloaded.


### PR DESCRIPTION
Instead of CHANGELOG.md being the document for the release notes, we created 2 separate documents.