### PR TITLE
Avoid double entry of first datapoint

### DIFF
--- a/DMI_Open_Data_dialog.py
+++ b/DMI_Open_Data_dialog.py
@@ -835,6 +835,15 @@ class DMIOpenDataDialog(QtWidgets.QDialog, FORM_CLASS):
                             listee = [row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]]
                         elif len(parameters) == 7:
                             listee = [row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10]]
+                        if stat1 == 'cellId':
+                            koordi = [QgsPointXY(koordinater[0][0][0], koordinater[0][0][1]),
+                                      QgsPointXY(koordinater[0][1][0], koordinater[0][1][1]), \
+                                      QgsPointXY(koordinater[0][2][0], koordinater[0][2][1]),
+                                      QgsPointXY(koordinater[0][3][0], koordinater[0][3][1]), \
+                                      QgsPointXY(koordinater[0][4][0], koordinater[0][4][1])]
+                            f.setGeometry(QgsGeometry.fromPolygonXY([koordi]))
+                        elif stat1 != 'cellId':
+                            f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(koordinater[0], koordinater[1])))
                         f.setAttributes(listee)
                         vl.addFeature(f)
                 elif data_type2 == 'observation' or data_type2 == 'countryValue':
@@ -853,22 +862,27 @@ class DMIOpenDataDialog(QtWidgets.QDialog, FORM_CLASS):
                             listee = [row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]]
                         elif len(parameters) == 7:
                             listee = [row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]]
+                        f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(koordinater[0], koordinater[1])))
                         f.setAttributes(listee)
                         vl.addFeature(f)
 # The coordinates are used based on which type of geometry (polygon or point).
-                if stat1 == 'stationId' or stat1 == 'municipalityId' or data_type2 == 'countryValue':
-                    f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(koordinater[0],koordinater[1])))
-                    vl.addFeature(f)
-                    vl.updateExtents()
-                    vl.commitChanges()
-                elif stat1 == 'cellId':
-                    koordi = [QgsPointXY(koordinater[0][0][0],koordinater[0][0][1]),QgsPointXY(koordinater[0][1][0],koordinater[0][1][1]),\
-                              QgsPointXY(koordinater[0][2][0],koordinater[0][2][1]),QgsPointXY(koordinater[0][3][0],koordinater[0][3][1]),\
-                              QgsPointXY(koordinater[0][4][0],koordinater[0][4][1])]
-                    f.setGeometry(QgsGeometry.fromPolygonXY([koordi]))
-                    vl.addFeature(f)
-                    vl.updateExtents()
-                    vl.commitChanges()
+
+                #if stat1 == 'stationId' or stat1 == 'municipalityId' or data_type2 == 'countryValue':
+                 #   f_geometry.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(koordinater[0],koordinater[1])))
+                    #vl.addFeature(f_geometry)
+                 #   vl.updateExtents()
+                  #  vl.commitChanges()
+                #elif stat1 == 'cellId':
+                 #   koordi = [QgsPointXY(koordinater[0][0][0],koordinater[0][0][1]),QgsPointXY(koordinater[0][1][0],koordinater[0][1][1]),\
+                  #            QgsPointXY(koordinater[0][2][0],koordinater[0][2][1]),QgsPointXY(koordinater[0][3][0],koordinater[0][3][1]),\
+                   #           QgsPointXY(koordinater[0][4][0],koordinater[0][4][1])]
+                    #f_geometry.setGeometry(QgsGeometry.fromPolygonXY([koordi]))
+                    #vl.addFeature(f_geometry)
+                    #vl.updateExtents()
+                    #vl.commitChanges()
+
+                vl.updateExtents()
+                vl.commitChanges()
                 QgsProject.instance().addMapLayer(vl)
 # The files are saved, if the user has chosen to write something in the "save as .csv" section
         if dataName == 'Meteorological Observations':


### PR DESCRIPTION
Due to a double call for setting feature, the first data entry was added twice. This has been removed. Now each data entry has its own coordinate to it also, allowing the user to scroll through time. 