### PR TITLE
Publish plugin through pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,23 @@ jobs:
             PARAM_GH_NOTES: <<parameters.notes-file>>
             PARAM_GH_TOKEN: <<parameters.token>>
           name: Creating a GitHub Release
+  upload: # Run unit tests, build installable zip
+    docker:
+      - image: cimg/python:3.8
+    parameters:
+      plugin_file:
+        default: ""
+        description: 'Plugin to be uploaded as compiled and installable ZIP file'
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: zip_build
+      - run:
+          name: Upload Plugin
+          command: python plugin_upload.py --username "@QGIS_USERNAME" --password "$QGIS_PASSWORD" "$PARAM_PLUGIN_FILE"
+          environment:
+            PARAM_PLUGIN_FILE: <<parameters.plugin_file>>
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -120,6 +137,16 @@ workflows:
           files: /home/circleci/project/zip_build/DMI_Open_Data.zip
           requires:
             - build-and-test
+          # Only on releases
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+      - upload:
+          plugin_file: /home/circleci/project/zip_build/DMI_Open_Data.zip
+          requires:
+            - release
           # Only on releases
           filters:
             branches:

--- a/plugin_upload.py
+++ b/plugin_upload.py
@@ -10,7 +10,7 @@ import getpass
 import xmlrpc.client
 from optparse import OptionParser
 
-standard_library.install_aliases()
+#standard_library.install_aliases()
 
 # Configuration
 PROTOCOL = 'https'


### PR DESCRIPTION
Fixed import issue with python standard_library.install_aliases(). Seems to cause issues on python 3.8, but imports work without it on python 3.8 at least.