### PR TITLE
Change label to match where station list comes from

### DIFF
--- a/DMI_Open_Data_dialog.py
+++ b/DMI_Open_Data_dialog.py
@@ -1171,9 +1171,9 @@ class DMIOpenDataDialog(QtWidgets.QDialog, FORM_CLASS):
             print(r.url)
             json = r.json()
             r_code = r.status_code
-            if r_code == 403:
+            if r_code == 403 or r_code == 401:
                 QMessageBox.warning(self, self.tr("DMI Open Data"),
-                                 self.tr('API Key is not valid or is expired / revoked.'))
+                                 self.tr('ClimateData or OceanObs API Key is not valid or is expired / revoked.'))
             else:
                 df = json_normalize(json['features'])
                 # Name and sort the data based on users preferences

--- a/DMI_Open_Data_dialog_base.ui
+++ b/DMI_Open_Data_dialog_base.ui
@@ -2571,7 +2571,7 @@
          <item>
           <widget class="QRadioButton" name="met_stat_info">
            <property name="text">
-            <string>Meteorological Stations</string>
+            <string>Climate Data Stations</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Noticed that the station list is not meteorological stations anymore but climate data stations, so have updated the label to reflect that.

Also made the error message clear about what API key is missing.