### PR TITLE
Implement validity filter on climate data station values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 orbs:
   python: circleci/python@2.0.3
-  gh: circleci/github-cli@2.1.0
+  gh: circleci/github-cli@2.7.2
 
 
 # Define a job to be invoked later in a workflow.

--- a/DMI_Open_Data_dialog_base.ui
+++ b/DMI_Open_Data_dialog_base.ui
@@ -133,8 +133,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>621</width>
-                   <height>283</height>
+                   <width>98</width>
+                   <height>28</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10"/>
@@ -164,8 +164,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>620</width>
-                   <height>283</height>
+                   <width>98</width>
+                   <height>28</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_5"/>
@@ -367,8 +367,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>66</width>
-                  <height>18</height>
+                  <width>98</width>
+                  <height>28</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_14"/>
@@ -443,8 +443,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>66</width>
-                  <height>18</height>
+                  <width>98</width>
+                  <height>28</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_40"/>
@@ -465,8 +465,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>66</width>
-                  <height>18</height>
+                  <width>98</width>
+                  <height>28</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_34"/>
@@ -487,8 +487,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>66</width>
-                  <height>18</height>
+                  <width>98</width>
+                  <height>28</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_38"/>
@@ -513,7 +513,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A valid value is quality controlled by DMIs climatologists and representative of the actual climate. By unchecking this box, you could retrieve data excluded by the climatologists because it is incorrect&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
-          <string>Only use valid values (Recommended)</string>
+          <string>Only get station values marked valid (Recommended)</string>
          </property>
          <property name="checked">
           <bool>true</bool>
@@ -1005,8 +1005,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>622</width>
-                 <height>285</height>
+                 <width>98</width>
+                 <height>28</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_100"/>
@@ -1148,7 +1148,7 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>600</width>
+                     <width>381</width>
                      <height>432</height>
                     </rect>
                    </property>
@@ -2667,8 +2667,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>18</width>
-                     <height>18</height>
+                     <width>98</width>
+                     <height>28</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout"/>

--- a/DMI_Open_Data_dialog_base.ui
+++ b/DMI_Open_Data_dialog_base.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>1345</width>
-    <height>528</height>
+    <height>613</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,7 +38,7 @@
       <bool>true</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="documentMode">
       <bool>false</bool>
@@ -133,8 +133,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>624</width>
-                   <height>246</height>
+                   <width>621</width>
+                   <height>283</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10"/>
@@ -164,8 +164,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>623</width>
-                   <height>246</height>
+                   <width>620</width>
+                   <height>283</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_5"/>
@@ -367,8 +367,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>66</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_14"/>
@@ -389,8 +389,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>628</width>
-                  <height>204</height>
+                  <width>629</width>
+                  <height>205</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_32"/>
@@ -421,8 +421,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>627</width>
-                  <height>204</height>
+                  <width>628</width>
+                  <height>205</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_36"/>
@@ -443,8 +443,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>66</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_40"/>
@@ -465,8 +465,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>66</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_34"/>
@@ -487,8 +487,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>98</width>
-                  <height>28</height>
+                  <width>66</width>
+                  <height>18</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_38"/>
@@ -503,6 +503,22 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="climate_station_value_validity_box">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A valid value is quality controlled by DMIs climatologists and representative of the actual climate. By unchecking this box, you could retrieve data excluded by the climatologists because it is incorrect&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Only use valid values (Recommended)</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QGroupBox" name="out_2">
@@ -989,8 +1005,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>625</width>
-                 <height>248</height>
+                 <width>622</width>
+                 <height>285</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_100"/>
@@ -1132,8 +1148,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>604</width>
-                     <height>348</height>
+                     <width>600</width>
+                     <height>432</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_60">
@@ -1328,8 +1344,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>251</width>
-                     <height>324</height>
+                     <width>332</width>
+                     <height>402</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_64">
@@ -2651,8 +2667,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>28</height>
+                     <width>18</width>
+                     <height>18</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout"/>
@@ -2921,22 +2937,25 @@
         <widget class="QTextBrowser" name="textBrowser">
          <property name="html">
           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;Plugin for DMIs Open Data &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Before starting&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;Documentation and more information about DMI Open Data can be found &lt;/span&gt;&lt;a href=&quot;https://www.dmi.dk/frie-data&quot;&gt;&lt;span style=&quot; font-size:11pt; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;. This guide will only briefly cover the plugin - not the data, stations etc.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;A thorough guide of how to use this plugin, along with examples, can be found &lt;/span&gt;&lt;a href=&quot;https://github.com/dmidk/Open-Data-QGIS-plugin/blob/master/Guide.md&quot;&gt;&lt;span style=&quot; font-size:11pt; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;The plugin allows the user to easily import data from DMIs Open Data from Meteorological Observations (metObs), Climate Data (climateData), Lightning Data (lightningData), Radar Data (radarData) and Oceanographic Observations (oceanObs).&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;How to use this plugin&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;&lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; font-size:11pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Maximum amount of parameters available is 7.&lt;/li&gt;
-&lt;li style=&quot; font-size:11pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Internet is neccessary in order to open the plugin and get data.&lt;/li&gt;
-&lt;li style=&quot; font-size:11pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Sort the data in a manner that your QGIS can handle. Otherwise there is a risk of crashing.&lt;/li&gt;
-&lt;li style=&quot; font-size:11pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Be sure to read about the stations and parameters, as not all stations measure all parameters. A list of meteorological stations and their associated parameters can also be found &lt;a href=&quot;https://www.dmi.dk/friedata/dokumentation/data/met-obs-data-stations-historical-availability&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;If you have any questions about the plugin or DMI Open Data then please contact us. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;Go to &lt;/span&gt;&lt;a href=&quot;https://www.dmi.dk/kontakt/frie-data/&quot;&gt;&lt;span style=&quot; font-size:11pt; text-decoration: underline; color:#0000ff;&quot;&gt;Contact form&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:11pt; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;Call DMI support: +45 39 15 75 00 &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu Sans'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt; font-weight:600;&quot;&gt;Plugin for DMIs Open Data &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600;&quot;&gt;Before starting&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;Documentation and more information about DMI Open Data can be found &lt;/span&gt;&lt;a href=&quot;https://www.dmi.dk/frie-data&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;. This guide will only briefly cover the plugin - not the data, stations etc.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;A thorough guide of how to use this plugin, along with examples, can be found &lt;/span&gt;&lt;a href=&quot;https://github.com/dmidk/Open-Data-QGIS-plugin/blob/master/Guide.md&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;. &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;The plugin allows the user to easily import data from DMIs Open Data from Meteorological Observations (metObs), Climate Data (climateData), Lightning Data (lightningData), Radar Data (radarData) and Oceanographic Observations (oceanObs).&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600;&quot;&gt;How to use this plugin&lt;/span&gt;&lt;/p&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
+&lt;li style=&quot; font-family:'MS Shell Dlg 2';&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Maximum amount of parameters available is 7.&lt;/li&gt;
+&lt;li style=&quot; font-family:'MS Shell Dlg 2';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Internet is neccessary in order to open the plugin and get data.&lt;/li&gt;
+&lt;li style=&quot; font-family:'MS Shell Dlg 2';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Sort the data in a manner that your QGIS can handle. Otherwise there is a risk of crashing.&lt;/li&gt;
+&lt;li style=&quot; font-family:'MS Shell Dlg 2';&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Be sure to read about the stations and parameters, as not all stations measure all parameters. A list of meteorological stations and their associated parameters can also be found &lt;a href=&quot;https://www.dmi.dk/friedata/dokumentation/data/met-obs-data-stations-historical-availability&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;If you have any questions about the plugin or DMI Open Data then please contact us. &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;Go to &lt;/span&gt;&lt;a href=&quot;https://www.dmi.dk/kontakt/frie-data/&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; text-decoration: underline; color:#0000ff;&quot;&gt;Contact form&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2';&quot;&gt;Call DMI support: +45 39 15 75 00 &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>


### PR DESCRIPTION
This implementation is not very sofisticated, the checkbox is present on all climate data value types even though it only applies to station values.

Validitity filtering is on by default, if unchecked then the filter is removed and both types can be included in the time series. There is no way of filtering for invalid values.

Screenshot of what the implementation looks like:

<img width="1352" height="1066" alt="qgis_plugin" src="https://github.com/user-attachments/assets/12a0329c-d185-498c-8cd8-9eb8d9113714" />
